### PR TITLE
pointing clone command to correct url

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,11 @@ The purpose of this library is to make it very simple to create standard, report
     ```commandline
     pip install revreports
     ```
-
-
 ###  From Source
 
 1. Clone the repository
     ```commandline
-    git clone git@github.nrel.gov:GDS/reVReports.git
+    git clone git@github.com:NREL/reVReports.git
     ```
 
 2. Move into the local repository


### PR DESCRIPTION
This is a simple PR that just fixes a bug in the README. Previously, the URL for cloning the repo still pointed to the enterprise repo. Now it points to the correct github.com URL.

